### PR TITLE
fix(task5): reload JSON into instances of BaseModel

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python3
+from models.base_model import BaseModel
 from models.engine.file_storage import FileStorage
 
 
 storage = FileStorage()
 storage.reload()
+
+__all__ = ["BaseModel", "storage"]

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -2,7 +2,7 @@
 """module containing the class BaseModel"""
 import uuid
 from datetime import datetime
-from models import storage
+import models
 
 
 class BaseModel():
@@ -28,7 +28,7 @@ class BaseModel():
             self.id = str(uuid.uuid4())
             self.created_at = datetime.now()
             self.updated_at = datetime.now()
-            storage.new(self)
+            models.storage.new(self)
 
     def __str__(self):
         """default print message"""
@@ -37,7 +37,7 @@ class BaseModel():
     def save(self):
         """Save the instance into storage with updated time"""
         self.updated_at = datetime.now()
-        storage.save()
+        models.storage.save()
 
     def remove(self, key):
         """removes object from storage

--- a/tests/test_models/test_imports.py
+++ b/tests/test_models/test_imports.py
@@ -1,0 +1,13 @@
+import unittest
+
+
+class TestImports(unittest.TestCase):
+    
+    def test_BaseModel_imports_model_and_storage(self):
+        from models import storage, BaseModel
+        
+        self.assertTrue(storage)
+        self.assertTrue(BaseModel)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit also fixes the circular import errors; however, I am not confident with Python's import mechanisms, so there may be a nicer way to do it.

A housekeeping item also: using the public interface `self.object` when the object mapping is referenced by `FileStorage` methods.