### PR TITLE
feat(task6): add basic command interpreter (closes #3)

### DIFF
--- a/console.py
+++ b/console.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""This is the logic and entry point for the AirBnB command interpreter."""
+import cmd
+
+
+class HBNBCommand(cmd.Cmd):
+    """This is the command interpreter for the AirBnB project."""
+    prompt = '(hbnb) '
+    
+    def do_quit(self, arg):
+        """Quit command to exit the program"""
+        return True
+    
+    def do_EOF(self, line):
+        """EOF command to exit the program (Ctrl+D)"""
+        return True
+
+    def emptyline(self):
+        """Do nothing on an empty input line"""
+        pass
+
+if __name__ == '__main__':
+    HBNBCommand().cmdloop()

--- a/tests/test_console/test_basic_interactions.py
+++ b/tests/test_console/test_basic_interactions.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python3
+from console import HBNBCommand
+from unittest.mock import patch
+import textwrap
+import unittest
+import io
+
+class TestPrompt(unittest.TestCase):
+    """
+    This class attempts to test the behaviour of the console in an 
+    implementation agnostic manner. It has not been entirely successful.
+    However, this underlying philosophy is why direct calls to the
+    methods that implement the commands are not made.
+    
+    ### Issues
+    
+    1) The mocked input is not written to the output.
+    2) It uses initilisation to redirect stdin and stdout, and further makes
+    use of an instance attribute, 'use_rawinput', to prevent calls to `input`.
+    """
+        
+    def test_that_console_displays_correct_prompt(self):
+        mocked_input = io.StringIO("")
+        output = io.StringIO() 
+
+        cmd = HBNBCommand(stdin=mocked_input, 
+                          stdout=output)
+        cmd.use_rawinput = False
+        
+        cmd.cmdloop()
+        self.assertEqual(output.getvalue(), "(hbnb) ")
+                
+    def test_help_command(self):
+        user_input = "help"
+        mocked_input = io.StringIO(user_input)
+        output = io.StringIO() 
+
+        cmd = HBNBCommand(stdin=mocked_input, 
+                          stdout=output)
+        cmd.use_rawinput = False
+        cmd.cmdloop()
+        
+        self.assertMultiLineEqual(output.getvalue(), textwrap.dedent("""\
+            (hbnb) 
+            Documented commands (type help <topic>):
+            ========================================
+            EOF  help  quit
+
+            (hbnb) """)
+        )
+                
+    def test_quit_command(self):
+        user_input = "quit"
+        mocked_input = io.StringIO(user_input)
+        output = io.StringIO() 
+
+        cmd = HBNBCommand(stdin=mocked_input, 
+                          stdout=output)
+        cmd.use_rawinput = False
+        cmd.cmdloop()
+        
+        self.assertEqual(output.getvalue(), "(hbnb) ")
+    
+    
+    def test_that_EOF_terminates_program(self):
+        user_input = "EOF"
+        mocked_input = io.StringIO(user_input)
+        output = io.StringIO() 
+
+        cmd = HBNBCommand(stdin=mocked_input, 
+                          stdout=output)
+        cmd.use_rawinput = False
+        cmd.cmdloop()
+        
+        self.assertEqual(output.getvalue(), "(hbnb) ")
+                
+    def test_that_help_topics_work(self):
+        user_input = "help EOF\nhelp quit\nhelp help"
+        mocked_input = io.StringIO(user_input)
+        output = io.StringIO() 
+
+        cmd = HBNBCommand(stdin=mocked_input, 
+                          stdout=output)
+        cmd.use_rawinput = False
+        cmd.cmdloop()
+        
+        self.assertEqual(output.getvalue(), textwrap.dedent("""\
+            (hbnb) EOF command to exit the program (Ctrl+D)
+            (hbnb) Quit command to exit the program
+            (hbnb) List available commands with "help" or detailed help with "help cmd".
+            (hbnb) """)
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Requirements
The command interpreter satisfies the following requirements:

- prompts the user with `(hnbn) ` - does nothing when an empty line is received
- exits on receiving `quit` and `EOF`
- lists available commands on receiving `help`
- shows detailed help with `help cmd`

### Tests
The feature is also supported by tests. I have been running them with

	`pytest tests/test_console`

You may need to `pip install pytest` to replicate my workflow.
However, the tests are written using `unittest`, so using pytest 
is not required.