### PR TITLE
ci(local): add pre-push hook and setup script

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Navigate back to the repo root
+cd "${PWD%/.git/hooks}"
+
+# Install dependencies
+python -m pip install --upgrade pip
+pip install pycodestyle pytest
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi
+
+# Run pycodestyle
+echo "Running pycodestyle..."
+pycodestyle . --max-line-length=127
+if [ $? -ne 0 ]; then
+    echo "pycodestyle checks failed."
+    exit 1
+fi
+
+# Run pytest
+echo "Running tests..."
+pytest tests/
+if [ $? -ne 0 ]; then
+    echo "Tests failed."
+    exit 1
+fi
+
+# If we got here, everything passed
+exit 0

--- a/hooks/setup.sh
+++ b/hooks/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cp hooks/* .git/hooks/
+chmod +x .git/hooks/*


### PR DESCRIPTION
Run `bash hooks/setup.sh` to install a pre-push hook onto your local. The hook will:

- pycodestyle your code
- run all tests in `tests/`